### PR TITLE
Removes jQuery in favor of document.querySelector()

### DIFF
--- a/example_embed.html
+++ b/example_embed.html
@@ -3,26 +3,27 @@
 <head>
   <meta charset="UTF-8">
   <title>Boots</title>
-    <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/swfobject/2.2/swfobject.min.js"></script>
     <script>
         function loadCP() {
-			$('#game')[0].toggleDebug();
-            $('#game')[0].startup("login-server.example.com", 6112, "http://media.example.com/");
+            var game = document.querySelector("#game");
+
+			game.toggleDebug();
+            game.startup("login-server.example.com", 6112, "http://media.example.com/");
         }
-        
+
         var flash = {};
-        
+
         var params = {
             menu: "false",
             allowScriptAccess: "always"
         };
-            
+
         var attrs = {
             id: "game",
             name: "game",
         };
-        
+
         swfobject.embedSWF("http://media.example.com/boots.swf", "game", "100%", "100%", "11.0.0", false, flash, params, attrs);
     </script>
 </head>

--- a/example_embed.html
+++ b/example_embed.html
@@ -8,7 +8,7 @@
         function loadCP() {
             var game = document.querySelector("#game");
 
-			game.toggleDebug();
+            game.toggleDebug();
             game.startup("login-server.example.com", 6112, "http://media.example.com/");
         }
 


### PR DESCRIPTION
Since IDs should only be used once and jQuery should only ever return a single instance of `div#game`, it would be more efficient to use [`document.querySelector()`](https://caniuse.com/#search=querySelector) which eliminates the need for jQuery.